### PR TITLE
DDCNL-10887: Remove config warnings for sca-wrapper-data

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -104,9 +104,13 @@ external-url {
   }
 }
 
-ur-banners = []
-ur-banners.max-items = 50
+ur-banners {
+  max-items = 50
+  items = []
+}
 
-webchat = []
-webchat.max-items = 50
+webchat {
+  max-items = 50
+  items = []
+}
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,12 +105,10 @@ external-url {
 }
 
 ur-banners {
-  max-items = 50
   items = []
 }
 
 webchat {
-  max-items = 50
   items = []
 }
 

--- a/test/uk/gov/hmrc/singlecustomeraccountwrapperdata/config/UrBannersConfigSpec.scala
+++ b/test/uk/gov/hmrc/singlecustomeraccountwrapperdata/config/UrBannersConfigSpec.scala
@@ -24,23 +24,23 @@ import uk.gov.hmrc.singlecustomeraccountwrapperdata.fixtures.BaseSpec
 class UrBannersConfigSpec extends BaseSpec {
 
   lazy val testBanner1: UrBanner = UrBanner("/home", "TestLink1", true)
-  lazy val testBanner2: UrBanner = UrBanner("/another-page", "TestLink2", false)
-  lazy val testBanner3: UrBanner = UrBanner("/second-service", "TestLink3", true)
+  lazy val testBanner2: UrBanner = UrBanner("/first-page", "TestLink2", false)
+  lazy val testBanner3: UrBanner = UrBanner("/second-page", "TestLink3", true)
 
   override implicit lazy val app: Application =
     GuiceApplicationBuilder()
       .configure(
-        "ur-banners.0.service"     -> "test-frontend",
-        "ur-banners.0.0.page"      -> testBanner1.page,
-        "ur-banners.0.0.link"      -> testBanner1.link,
-        "ur-banners.0.0.isEnabled" -> testBanner1.isEnabled,
-        "ur-banners.0.1.page"      -> testBanner2.page,
-        "ur-banners.0.1.link"      -> testBanner2.link,
-        "ur-banners.0.1.isEnabled" -> testBanner2.isEnabled,
-        "ur-banners.1.service"     -> "second-frontend",
-        "ur-banners.1.0.page"      -> testBanner3.page,
-        "ur-banners.1.0.link"      -> testBanner3.link,
-        "ur-banners.1.0.isEnabled" -> testBanner3.isEnabled
+        "ur-banners.items.0.service"             -> "test-frontend-1",
+        "ur-banners.items.0.entries.0.page"      -> testBanner1.page,
+        "ur-banners.items.0.entries.0.link"      -> testBanner1.link,
+        "ur-banners.items.0.entries.0.isEnabled" -> testBanner1.isEnabled,
+        "ur-banners.items.0.entries.1.page"      -> testBanner2.page,
+        "ur-banners.items.0.entries.1.link"      -> testBanner2.link,
+        "ur-banners.items.0.entries.1.isEnabled" -> testBanner2.isEnabled,
+        "ur-banners.items.1.service"             -> "test-frontend-2",
+        "ur-banners.items.1.entries.0.page"      -> testBanner3.page,
+        "ur-banners.items.1.entries.0.link"      -> testBanner3.link,
+        "ur-banners.items.1.entries.0.isEnabled" -> testBanner3.isEnabled
       )
       .build()
 
@@ -48,11 +48,20 @@ class UrBannersConfigSpec extends BaseSpec {
 
   "UrBannersConfig" must {
     "return a list of banners for all services" in {
-      bannersConfig.getUrBannersByService must be
-      Map(
-        "test-frontend"                     -> List(testBanner1, testBanner2),
-        "second-frontend"                   -> List(testBanner3)
-      )
+      bannersConfig.getUrBannersByService mustBe
+        Map(
+          "test-frontend-1" -> List(testBanner1, testBanner2),
+          "test-frontend-2" -> List(testBanner3)
+        )
+    }
+
+    "return empty map when no items are present" in {
+      val appWithEmptyConfig = GuiceApplicationBuilder()
+        .configure("ur-banners.items" -> List.empty)
+        .build()
+
+      val emptyConfig = appWithEmptyConfig.injector.instanceOf[UrBannersConfig]
+      emptyConfig.getUrBannersByService mustBe Map.empty
     }
   }
 

--- a/test/uk/gov/hmrc/singlecustomeraccountwrapperdata/config/WebchatConfigSpec.scala
+++ b/test/uk/gov/hmrc/singlecustomeraccountwrapperdata/config/WebchatConfigSpec.scala
@@ -23,24 +23,24 @@ import uk.gov.hmrc.singlecustomeraccountwrapperdata.fixtures.BaseSpec
 
 class WebchatConfigSpec extends BaseSpec {
 
-  lazy val testWebchat1: Webchat = Webchat("/home", "skin", true)
-  lazy val testWebchat2: Webchat = Webchat("/another-page", "Alternate", false)
-  lazy val testWebchat3: Webchat = Webchat("/second-service", "skin", true)
+  lazy val testWebchat1: Webchat = Webchat("^/pattern1", "skin", true)
+  lazy val testWebchat2: Webchat = Webchat("^/pattern2/sub.*", "Alternate", false)
+  lazy val testWebchat3: Webchat = Webchat("^/pattern3.*", "skin", true)
 
   override implicit lazy val app: Application =
     GuiceApplicationBuilder()
       .configure(
-        "webchat.0.service"       -> "test-frontend",
-        "webchat.0.0.pattern"     -> testWebchat1.pattern,
-        "webchat.0.0.skinElement" -> testWebchat1.skinElement,
-        "webchat.0.0.isEnabled"   -> testWebchat1.isEnabled,
-        "webchat.0.1.pattern"     -> testWebchat2.pattern,
-        "webchat.0.1.skinElement" -> testWebchat2.skinElement,
-        "webchat.0.1.isEnabled"   -> testWebchat2.isEnabled,
-        "webchat.1.service"       -> "second-frontend",
-        "webchat.1.0.pattern"     -> testWebchat3.pattern,
-        "webchat.1.0.skinElement" -> testWebchat3.skinElement,
-        "webchat.1.0.isEnabled"   -> testWebchat3.isEnabled
+        "webchat.items.0.service"               -> "test-frontend-1",
+        "webchat.items.0.entries.0.pattern"     -> testWebchat1.pattern,
+        "webchat.items.0.entries.0.skinElement" -> testWebchat1.skinElement,
+        "webchat.items.0.entries.0.isEnabled"   -> testWebchat1.isEnabled,
+        "webchat.items.0.entries.1.pattern"     -> testWebchat2.pattern,
+        "webchat.items.0.entries.1.skinElement" -> testWebchat2.skinElement,
+        "webchat.items.0.entries.1.isEnabled"   -> testWebchat2.isEnabled,
+        "webchat.items.1.service"               -> "test-frontend-2",
+        "webchat.items.1.entries.0.pattern"     -> testWebchat3.pattern,
+        "webchat.items.1.entries.0.skinElement" -> testWebchat3.skinElement,
+        "webchat.items.1.entries.0.isEnabled"   -> testWebchat3.isEnabled
       )
       .build()
 
@@ -48,11 +48,20 @@ class WebchatConfigSpec extends BaseSpec {
 
   "WebchatConfig" must {
     "return a list of webchat pages for all services" in {
-      webchatConfig.getWebchatUrlsByService must be
-      Map(
-        "test-frontend"                       -> List(testWebchat1, testWebchat2),
-        "second-frontend"                     -> List(testWebchat3)
-      )
+      webchatConfig.getWebchatUrlsByService mustBe
+        Map(
+          "test-frontend-1" -> List(testWebchat1, testWebchat2),
+          "test-frontend-2" -> List(testWebchat3)
+        )
+    }
+
+    "return empty map when no items are present" in {
+      val appWithEmptyConfig = GuiceApplicationBuilder()
+        .configure("webchat.items" -> List.empty)
+        .build()
+
+      val emptyConfig = appWithEmptyConfig.injector.instanceOf[WebchatConfig]
+      emptyConfig.getWebchatUrlsByService mustBe Map.empty
     }
   }
 


### PR DESCRIPTION
- Replaced indexed configuration for webchat and ur-banners (e.g. webchat.0.0.pattern, ur-banners.1.0.page) with new list based structure using _items = [...]_ . 

- Updated corresponding config readers (UrBannersConfig, WebchatConfig) to support new structure and removed _.max-items_, which was only relevant to the old config parsing logic.

- Verified ur-banners and webchat items.

